### PR TITLE
[Fix #115863415] Fix broken url on editing a video

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -82,6 +82,7 @@ class DashboardController extends Controller
             return redirect()->route('homepage');
         }
 
+        $request['url'] = $this->videoRepository->makeYoutubeUrl($request->all()['url']);
         $video->update($request->all());
         $this->syncCategories($video, $request->input('category_list'));
 


### PR DESCRIPTION
#### What does this PR do?

Fix broken url on editing a video
#### Description of Task to be completed?

When a user edits a video, the url is broken.
It persists the entire url to the database as opposed to the video id.
Ensure that valid video id is persited into the database
#### How should this be manually tested?

Login
Create video
Edit video,
See that video plays
#### What are the relevant pivotal tracker stories?
#115863415
